### PR TITLE
Add to calendar button

### DIFF
--- a/assets/scss/components/_event.scss
+++ b/assets/scss/components/_event.scss
@@ -96,14 +96,31 @@
   line-height: 5px;
 }
 
-@media only screen and (min-width: 415px) and (max-width: 770px) {
+.calendar-icons{
+  display: flex;
+  justify-content: space-between;
+  width: 35%;
+}
+
+@media only screen and (min-width: 771px) and (max-width: 810px){
+  .date_card_about {
+    margin-top: -100px;
+    margin-left: 650px;
+  }
+
+  .calendar-icons{
+    width: 40%;
+  }
+}
+
+@media only screen and (min-width: 429px) and (max-width: 770px) {
   .date_card_about {
     margin-top: -100px;
     margin-left: 600px;
   }
 }
 
-@media only screen and (min-width: 380px) and (max-width: 414px) {
+@media only screen and (min-width: 380px) and (max-width: 428px) {
   .event_container {
     flex-direction: column;
 
@@ -119,7 +136,11 @@
 
   .date_card_about {
     margin-top: -100px;
-    margin-left: 270px;
+    margin-left: 260px;
+  }
+
+  .calendar-icons{
+    width: 40%;
   }
 }
 
@@ -140,6 +161,10 @@
     margin-top: -100px;
     margin-left: 240px;
   }
+
+  .calendar-icons{
+    width: 45%;
+  }
 }
 
 @media only screen and (max-width: 360px) {
@@ -159,10 +184,10 @@
     margin-top: -100px;
     margin-left: 225px;
   }
+
+  .calendar-icons{
+    width: 50%;
+  }
 }
 
-.calendar-icons{
-  display: flex;
-  justify-content: space-between;
-  width: 50%;
-}
+

--- a/assets/scss/components/_event.scss
+++ b/assets/scss/components/_event.scss
@@ -160,3 +160,9 @@
     margin-left: 225px;
   }
 }
+
+.calendar-icons{
+  display: flex;
+  justify-content: space-between;
+  width: 50%;
+}

--- a/assets/scss/components/_event.scss
+++ b/assets/scss/components/_event.scss
@@ -96,19 +96,19 @@
   line-height: 5px;
 }
 
-.calendar-icons{
+.calendar-icons {
   display: flex;
   justify-content: space-between;
   width: 35%;
 }
 
-@media only screen and (min-width: 771px) and (max-width: 810px){
+@media only screen and (min-width: 771px) and (max-width: 810px) {
   .date_card_about {
     margin-top: -100px;
     margin-left: 650px;
   }
 
-  .calendar-icons{
+  .calendar-icons {
     width: 40%;
   }
 }
@@ -139,7 +139,7 @@
     margin-left: 260px;
   }
 
-  .calendar-icons{
+  .calendar-icons {
     width: 40%;
   }
 }
@@ -162,7 +162,7 @@
     margin-left: 240px;
   }
 
-  .calendar-icons{
+  .calendar-icons {
     width: 45%;
   }
 }
@@ -185,9 +185,7 @@
     margin-left: 225px;
   }
 
-  .calendar-icons{
+  .calendar-icons {
     width: 50%;
   }
 }
-
-

--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -68,15 +68,44 @@
       return outlookUrl + details;
     }
 
+    function generateAppleICSFileSingleDay(startDate, endDate){
+      let startDateStr = `${startDate.getUTCFullYear()}${(startDate.getUTCMonth() + 1).toString().padStart(2, "0")}${startDate.getUTCDate().toString().padStart(2, "0")}T${startDate.getUTCHours().toString().padStart(2, "0")}${startDate.getUTCMinutes().toString().padStart(2, "0")}Z`
+      let endDateStr = `${endDate.getUTCFullYear()}${(endDate.getUTCMonth() + 1).toString().padStart(2, "0")}${endDate.getUTCDate().toString().padStart(2, "0")}T${endDate.getUTCHours().toString().padStart(2, "0")}${endDate.getUTCMinutes().toString().padStart(2, "0")}Z`
+      
+      let event = 
+        "BEGIN:VCALENDAR\n" +
+        "VERSION:2.0\n" +
+        "PRODID:-//ccss.carleton.ca//EN\n" +
+        "BEGIN:VEVENT\n" +
+        "SEQUENCE:0\n" +
+        "DTSTART:"+startDateStr+"\n" +
+        "DTEND:"+endDateStr+"\n" +
+        "SUMMARY:"+{{ .Params.title }}+"\n" +
+        "LOCATION:"+{{ .Params.location }}+"\n" +
+        "DESCRIPTION:"+{{ .Params.short_description }}+"\n" +
+        "END:VEVENT\n" +
+        "END:VCALENDAR\n"
+
+      let file = new File([event], {type: "text/plain" })
+
+      return window.URL.createObjectURL(file)
+    }
+
     window.onload = function(){
-      let startDate, endDate;
-      [startDate, endDate] = convertDateSingleDay({{ .Params.date }}, {{ .Params.start_time }})
+      if {{ .Params.start_time }}.includes("PM") || {{ .Params.start_time }}.includes("AM"){
+        let startDate, endDate;
+        [startDate, endDate] = convertDateSingleDay({{ .Params.date }}, {{ .Params.start_time }})
 
-      const gCalButton = document.getElementById("g-cal-button")
-      gCalButton.href = generateGCalLinkSingleDay(startDate, endDate)
+        const gCalButton = document.getElementById("g-cal-button")
+        gCalButton.href = generateGCalLinkSingleDay(startDate, endDate)
 
-      const outlookButton = document.getElementById("outlook-button")
-      outlookButton.href = generateOutlookLinkSingleDay(startDate, endDate)
+        const outlookButton = document.getElementById("outlook-button")
+        outlookButton.href = generateOutlookLinkSingleDay(startDate, endDate)
+      
+        const appleButton = document.getElementById("apple-button")
+        appleButton.href = generateAppleICSFileSingleDay(startDate, endDate)
+        appleButton.download = {{ .Params.title }} + ".ics"
+      }
     }
 
   </script>

--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -2,66 +2,88 @@
   {{- partial "navbar_temp.html" . -}}
   <script src="https://code.iconify.design/iconify-icon/1.0.0/iconify-icon.min.js"></script>
   <script type="text/javascript">
-    function generateGCalLink(){
-      let gCalUrl = new URL("https://www.google.com/calendar/render?");
-      let details = new URLSearchParams(gCalUrl.search)
+    function convertDateSingleDay(dateStr, time){
+      let dateSplit = dateStr.split("T")[0].split("-")
 
-      const monthDict = {
-        "Jan" : "01",
-        "Feb" : "02",
-        "Mar" : "03",
-        "Apr" : "04",
-        "May" : "05",
-        "Jun" : "06",
-        "Jul" : "07",
-        "Aug" : "08",
-        "Sep" : "09",
-        "Oct" : "10",
-        "Nov" : "11",
-        "Dec" : "12"
-      }
+      let startTimeHour = parseInt(time.split(" ")[0].split(":")[0])
+      let endTimeHour = parseInt(time.split(" ")[2].split(":")[0])
+      let startTimeMinute = parseInt(time.split(" ")[0].split(":")[1])
+      let endTimeMinute = parseInt(time.split(" ")[2].split(":")[1])
 
-      const dateString = {{ .Params.date.Format "2006" }} + monthDict[{{ .Params.date.Format "Jan" }}] + {{ .Params.date.Format "2" }}
-      let startTimeHour = parseInt({{ .Params.start_time }}.split(" ")[0].split(":")[0])
-      let endTimeHour = parseInt({{ .Params.start_time }}.split(" ")[2].split(":")[0])
+      // times need to be convered to 24 hour, then need 4 hours added
+      // to match UTC
 
       // event begins in the morning and ends in the afternoon/evening
       // only convert endtime to 24 hour time
       // e.g 11:00 AM - 3:00 PM
       if (startTimeHour > endTimeHour){
-        endTimeHour += 12
-      
+        endTimeHour += 16
+
       // event starts and ends in the afternoon/evening OR starts in the morning and ends at 12PM
       // convert both times to 24 hour time
       // e.g 1:00 - 3:00 PM
       // e.g 11:00 - 12:00 PM
-      }else if ( {{ .Params.start_time}}.includes("PM") && endTimeHour < 12){
-        startTimeHour += 12
-        endTimeHour += 12
+      }else if ( {{ .Params.start_time }}.includes("PM") && endTimeHour < 12){
+        startTimeHour += 16
+        endTimeHour += 16
       }
 
-      // startTimeHour = (startTimeHour + 4) % 24
-      // endTimeHour = (endTimeHour + 4) % 24
+      // Using Date.UTC because javascript likes to mess with daylight savings
+      let startDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), startTimeHour, startTimeMinute, 0))
+      let endDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), endTimeHour, endTimeMinute, 0))
 
-      // if an event starts and ends in the AM then they are already in 24 hour time
-      // e.g 10:00 - 11:00 AM
+      return [startDate, endDate]
+    }
 
-      const startTime = startTimeHour.toString() + {{ .Params.start_time }}.split(" ")[0].split(":")[1] + "00"
-      const endTime = endTimeHour.toString() + {{ .Params.start_time }}.split(" ")[2].split(":")[1] + "00"
+    function generateGCalLinkSingleDay(){
+      let gCalUrl = new URL("https://www.google.com/calendar/render?");
+      let details = new URLSearchParams(gCalUrl.search)
+
+      let startDate, endDate;
+      [startDate, endDate] = convertDateSingleDay({{ .Params.date }}, {{ .Params.start_time }})
+
+      let startDateStr = `${startDate.getUTCFullYear()}${(startDate.getUTCMonth() + 1).toString().padStart(2, "0")}${startDate.getUTCDate().toString().padStart(2, "0")}T${startDate.getUTCHours().toString().padStart(2, "0")}${startDate.getUTCMinutes().toString().padStart(2, "0")}00Z/`
+      let endDateStr = `${endDate.getUTCFullYear()}${(endDate.getUTCMonth() + 1).toString().padStart(2, "0")}${endDate.getUTCDate().toString().padStart(2, "0")}T${endDate.getUTCHours().toString().padStart(2, "0")}${endDate.getUTCMinutes().toString().padStart(2, "0")}00Z`
+      let fullDateStr = startDateStr + endDateStr
+      // alert(fullDateStr)
 
       details.append("action", "TEMPLATE");
       details.append("text", {{ .Params.title }});
       details.append("details", {{ .Params.short_description }});
       details.append("location", {{ .Params.location }});
-      details.append("dates", dateString + "T" + startTime + "E/" + dateString + "T" + endTime + "E");
+      details.append("dates", fullDateStr);
+
+      // alert(gCalUrl + details)
+
       return gCalUrl + details;
+    }
+
+    function generateOutlookLinkSingleDay(){
+      let outlookUrl = new URL("https://outlook.live.com/calendar/0/deeplink/compose?");
+      let details = new URLSearchParams(outlookUrl.search)
+
+      details.append("allday", "false");
+      details.append("body", {{ .Params.short_description }});
+      // details.append("enddt", {{ .Params.date.Format "2006-01-02" }} + "T" + {{ .Params.start_time }}.split(" ")[2] + ":00" + "-04:00");
+      details.append("location", {{ .Params.location }});
+      details.append("path", "/calendar/action/compose");
+      details.append("rru", "addevent");
+      // details.append("startdt", {{ .Params.date.Format "2006-01-02" }} + "T" + {{ .Params.start_time }}.split(" ")[0] + ":00" + "-04:00");
+      details.append("subject", {{ .Params.title }});
+
+      // alert(outlookUrl + details)
+
+      return outlookUrl + details;
     }
 
     window.onload = function(){
       gCalButton = document.getElementById("g-cal-button")
-      gCalButton.href = generateGCalLink()
+      gCalButton.href = generateGCalLinkSingleDay()
+
+      outlookButton = document.getElementById("outlook-button")
+      outlookButton.href = generateOutlookLinkSingleDay()
     }
-     
+
   </script>
   <div class="event-page">
     <!--Background-->
@@ -110,10 +132,32 @@
           <div>
             <div class="event-subtitle">ADD TO CALENDAR</div>
             <div class="calendar-icons">
-              <a id="g-cal-button" target="_blank"><iconify-icon  class="hvr-float" icon="akar-icons:google-fill" style="color: #c40729;" width="30"></iconify-icon></a>
-              <a id="apple-button" target="_blank"><iconify-icon id="apple-button" class="hvr-float" icon="ant-design:apple-filled" style="color: #c40729;" width="30"></iconify-icon></a>
-              <a id="outlook-button" target="_blank"><iconify-icon id="outlook-button" class="hvr-float" icon="file-icons:microsoft-outlook" style="color: #c40729;" width="30"></iconify-icon></a>
-              <a id="yahoo-button" target="_blank"><iconify-icon id="yahoo-button" class="hvr-float" icon="mdi:yahoo" style="color: #c40729;" width="30"></iconify-icon></a>
+              <a id="g-cal-button" target="_blank"
+                ><iconify-icon
+                  class="hvr-float"
+                  icon="akar-icons:google-fill"
+                  style="color: #c40729;"
+                  width="30"
+                ></iconify-icon
+              ></a>
+              <a id="outlook-button" target="_blank"
+                ><iconify-icon
+                  id="outlook-button"
+                  class="hvr-float"
+                  icon="file-icons:microsoft-outlook"
+                  style="color: #c40729;"
+                  width="30"
+                ></iconify-icon
+              ></a>
+              <a id="apple-button" target="_blank"
+                ><iconify-icon
+                  id="apple-button"
+                  class="hvr-float"
+                  icon="ant-design:apple-filled"
+                  style="color: #c40729;"
+                  width="30"
+                ></iconify-icon
+              ></a>
             </div>
           </div>
         </div>

--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -3,7 +3,7 @@
   <script src="https://code.iconify.design/iconify-icon/1.0.0/iconify-icon.min.js"></script>
   <script type="text/javascript">
     function convertDateSingleDay(dateStr, time){
-      let dateSplit = dateStr.split("T")[0].split("-")
+      const dateSplit = dateStr.split("T")[0].split("-")
 
       let startTimeHour = parseInt(time.split(" ")[0].split(":")[0])
       let endTimeHour = parseInt(time.split(" ")[2].split(":")[0])
@@ -29,23 +29,19 @@
       }
 
       // Using Date.UTC because javascript likes to mess with daylight savings
-      let startDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), startTimeHour, startTimeMinute, 0))
-      let endDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), endTimeHour, endTimeMinute, 0))
+      const startDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), startTimeHour, startTimeMinute, 0))
+      const endDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), endTimeHour, endTimeMinute, 0))
 
       return [startDate, endDate]
     }
 
-    function generateGCalLinkSingleDay(){
+    function generateGCalLinkSingleDay(startDate, endDate){
       let gCalUrl = new URL("https://www.google.com/calendar/render?");
       let details = new URLSearchParams(gCalUrl.search)
-
-      let startDate, endDate;
-      [startDate, endDate] = convertDateSingleDay({{ .Params.date }}, {{ .Params.start_time }})
 
       let startDateStr = `${startDate.getUTCFullYear()}${(startDate.getUTCMonth() + 1).toString().padStart(2, "0")}${startDate.getUTCDate().toString().padStart(2, "0")}T${startDate.getUTCHours().toString().padStart(2, "0")}${startDate.getUTCMinutes().toString().padStart(2, "0")}00Z/`
       let endDateStr = `${endDate.getUTCFullYear()}${(endDate.getUTCMonth() + 1).toString().padStart(2, "0")}${endDate.getUTCDate().toString().padStart(2, "0")}T${endDate.getUTCHours().toString().padStart(2, "0")}${endDate.getUTCMinutes().toString().padStart(2, "0")}00Z`
       let fullDateStr = startDateStr + endDateStr
-      // alert(fullDateStr)
 
       details.append("action", "TEMPLATE");
       details.append("text", {{ .Params.title }});
@@ -53,35 +49,34 @@
       details.append("location", {{ .Params.location }});
       details.append("dates", fullDateStr);
 
-      // alert(gCalUrl + details)
-
       return gCalUrl + details;
     }
 
-    function generateOutlookLinkSingleDay(){
+    function generateOutlookLinkSingleDay(startDate, endDate){
       let outlookUrl = new URL("https://outlook.live.com/calendar/0/deeplink/compose?");
       let details = new URLSearchParams(outlookUrl.search)
 
       details.append("allday", "false");
       details.append("body", {{ .Params.short_description }});
-      // details.append("enddt", {{ .Params.date.Format "2006-01-02" }} + "T" + {{ .Params.start_time }}.split(" ")[2] + ":00" + "-04:00");
+      details.append("enddt", endDate.toISOString());
       details.append("location", {{ .Params.location }});
       details.append("path", "/calendar/action/compose");
       details.append("rru", "addevent");
-      // details.append("startdt", {{ .Params.date.Format "2006-01-02" }} + "T" + {{ .Params.start_time }}.split(" ")[0] + ":00" + "-04:00");
+      details.append("startdt", startDate.toISOString());
       details.append("subject", {{ .Params.title }});
-
-      // alert(outlookUrl + details)
 
       return outlookUrl + details;
     }
 
     window.onload = function(){
-      gCalButton = document.getElementById("g-cal-button")
-      gCalButton.href = generateGCalLinkSingleDay()
+      let startDate, endDate;
+      [startDate, endDate] = convertDateSingleDay({{ .Params.date }}, {{ .Params.start_time }})
 
-      outlookButton = document.getElementById("outlook-button")
-      outlookButton.href = generateOutlookLinkSingleDay()
+      const gCalButton = document.getElementById("g-cal-button")
+      gCalButton.href = generateGCalLinkSingleDay(startDate, endDate)
+
+      const outlookButton = document.getElementById("outlook-button")
+      outlookButton.href = generateOutlookLinkSingleDay(startDate, endDate)
     }
 
   </script>

--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -28,9 +28,45 @@
         endTimeHour += 16
       }
 
+      const year = parseInt(dateSplit[0])
+      const month = parseInt(dateSplit[1]) - 1
+      const day = parseInt(dateSplit[2])
+
       // Using Date.UTC because javascript likes to mess with daylight savings
-      const startDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), startTimeHour, startTimeMinute, 0))
-      const endDate = new Date(Date.UTC(parseInt(dateSplit[0]), parseInt(dateSplit[1]) - 1, parseInt(dateSplit[2]), endTimeHour, endTimeMinute, 0))
+      const startDate = new Date(Date.UTC(year, month, day, startTimeHour, startTimeMinute, 0))
+      const endDate = new Date(Date.UTC(year, month, day, endTimeHour, endTimeMinute, 0))
+
+      return [startDate, endDate]
+    }
+
+    function convertDateMultiDay(yearStr, dateStr){
+      const monthToInt = {
+        "Jan": 0,
+        "Feb": 1,
+        "Mar": 2,
+        "Apr": 3,
+        "May": 4,
+        "Jun": 5,
+        "Jul": 6,
+        "Aug": 7,
+        "Sept": 8,
+        "Oct": 9,
+        "Nov": 10,
+        "Dec": 11
+      }
+      
+      const yearSplit = yearStr.split("T")[0].split("-")
+      const dateSplit = dateStr.split(" - ")
+
+      const year = parseInt(yearSplit[0])
+      const startMonth = monthToInt[dateSplit[0].split(" ")[0]]
+      const startDay = parseInt(dateSplit[0].split(" ")[1])
+
+      const endMonth = monthToInt[dateSplit[1].split(" ")[0]]
+      const endDay = parseInt(dateSplit[1].split(" ")[1])
+
+      const startDate = new Date(Date.UTC(year, startMonth, startDay, 4, 0, 0))
+      const endDate = new Date(Date.UTC(year, endMonth, endDay, 4, 0, 0))
 
       return [startDate, endDate]
     }
@@ -69,8 +105,8 @@
     }
 
     function generateAppleICSFileSingleDay(startDate, endDate){
-      let startDateStr = `${startDate.getUTCFullYear()}${(startDate.getUTCMonth() + 1).toString().padStart(2, "0")}${startDate.getUTCDate().toString().padStart(2, "0")}T${startDate.getUTCHours().toString().padStart(2, "0")}${startDate.getUTCMinutes().toString().padStart(2, "0")}Z`
-      let endDateStr = `${endDate.getUTCFullYear()}${(endDate.getUTCMonth() + 1).toString().padStart(2, "0")}${endDate.getUTCDate().toString().padStart(2, "0")}T${endDate.getUTCHours().toString().padStart(2, "0")}${endDate.getUTCMinutes().toString().padStart(2, "0")}Z`
+      let startDateStr = `${startDate.getUTCFullYear()}${(startDate.getUTCMonth() + 1).toString().padStart(2, "0")}${startDate.getUTCDate().toString().padStart(2, "0")}T${startDate.getUTCHours().toString().padStart(2, "0")}${startDate.getUTCMinutes().toString().padStart(2, "0")}00Z`
+      let endDateStr = `${endDate.getUTCFullYear()}${(endDate.getUTCMonth() + 1).toString().padStart(2, "0")}${endDate.getUTCDate().toString().padStart(2, "0")}T${endDate.getUTCHours().toString().padStart(2, "0")}${endDate.getUTCMinutes().toString().padStart(2, "0")}00Z`
       
       let event = 
         "BEGIN:VCALENDAR\n" +
@@ -92,20 +128,21 @@
     }
 
     window.onload = function(){
-      if {{ .Params.start_time }}.includes("PM") || {{ .Params.start_time }}.includes("AM"){
-        let startDate, endDate;
+      let startDate, endDate;
+      const gCalButton = document.getElementById("g-cal-button")
+      const outlookButton = document.getElementById("outlook-button")
+      const appleButton = document.getElementById("apple-button")
+
+      if ({{ .Params.start_time }}.includes("PM") || {{ .Params.start_time }}.includes("AM")){
         [startDate, endDate] = convertDateSingleDay({{ .Params.date }}, {{ .Params.start_time }})
-
-        const gCalButton = document.getElementById("g-cal-button")
-        gCalButton.href = generateGCalLinkSingleDay(startDate, endDate)
-
-        const outlookButton = document.getElementById("outlook-button")
-        outlookButton.href = generateOutlookLinkSingleDay(startDate, endDate)
-      
-        const appleButton = document.getElementById("apple-button")
-        appleButton.href = generateAppleICSFileSingleDay(startDate, endDate)
-        appleButton.download = {{ .Params.title }} + ".ics"
+      }else{
+        [startDate, endDate] = convertDateMultiDay( {{ .Params.date }}, {{ .Params.start_time }} )
       }
+      
+      gCalButton.href = generateGCalLinkSingleDay(startDate, endDate)
+      outlookButton.href = generateOutlookLinkSingleDay(startDate, endDate)
+      appleButton.href = generateAppleICSFileSingleDay(startDate, endDate)
+      appleButton.download = {{ .Params.date }} + "-" + {{ .Params.title }} + ".ics"
     }
 
   </script>

--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -1,5 +1,46 @@
 {{ define "main" }}
   {{- partial "navbar_temp.html" . -}}
+  <script src="https://code.iconify.design/iconify-icon/1.0.0/iconify-icon.min.js"></script>
+  <script type="text/javascript">
+     function generateGCalLink(){
+      let gCalUrl = new URL("https://www.google.com/calendar/render?");
+      let details = new URLSearchParams(gCalUrl.search)
+
+      const monthDict = {
+        "Jan" : "01",
+        "Feb" : "02",
+        "Mar" : "03",
+        "Apr" : "04",
+        "May" : "05",
+        "Jun" : "06",
+        "Jul" : "07",
+        "Aug" : "08",
+        "Sep" : "09",
+        "Oct" : "10",
+        "Nov" : "11",
+        "Dec" : "12"
+      }
+
+      const dateString = {{ .Params.date.Format "2006" }} + monthDict[{{ .Params.date.Format "Jan" }}] + {{ .Params.date.Format "2" }}
+      // const startTime = {{ .Params.start_time }}.split(" ")[0].replace(":", "").replace(" ", "").padStart(4, "0").padEnd(6, "0")
+      // const endTime = {{ .Params.start_time }}.split(" ")[2].replace(":", "").replace(" ", "").padStart(4, "0").padEnd(6, "0")
+      // Have to convert these to 12 hour time
+
+
+      details.append("action", "TEMPLATE");
+      details.append("text", {{ .Params.title }});
+      details.append("details", {{ .Params.short_description }});
+      details.append("location", {{ .Params.location }});
+      details.append("dates", dateString + "T" + startTime + "E" + "%2F" + dateString + "T" + endTime);
+      return gCalUrl + details;
+    }
+
+    window.onload = function(){
+      gCalButton = document.getElementById("g-cal-button")
+      gCalButton.href = generateGCalLink()
+    }
+     
+  </script>
   <div class="event-page">
     <!--Background-->
     {{- if ne .Params.hideBanner true }}
@@ -43,6 +84,15 @@
             <a href="{{ .Params.location_link }}"
               >{{- partial "button.html" (dict "label" .Params.location) -}}</a
             >
+          </div>
+          <div>
+            <div class="event-subtitle">ADD TO CALENDAR</div>
+            <div class="calendar-icons">
+              <a id="g-cal-button" target="_blank"><iconify-icon  class="hvr-float" icon="akar-icons:google-fill" style="color: #c40729;" width="30"></iconify-icon></a>
+              <iconify-icon id="apple-button" class="hvr-float" icon="ant-design:apple-filled" style="color: #c40729;" width="30"></iconify-icon>
+              <iconify-icon id="outlook-button" class="hvr-float" icon="file-icons:microsoft-outlook" style="color: #c40729;" width="30"></iconify-icon>
+              <iconify-icon id="yahoo-button" class="hvr-float" icon="mdi:yahoo" style="color: #c40729;" width="30"></iconify-icon>
+            </div>
           </div>
         </div>
       </div>

--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -2,7 +2,7 @@
   {{- partial "navbar_temp.html" . -}}
   <script src="https://code.iconify.design/iconify-icon/1.0.0/iconify-icon.min.js"></script>
   <script type="text/javascript">
-     function generateGCalLink(){
+    function generateGCalLink(){
       let gCalUrl = new URL("https://www.google.com/calendar/render?");
       let details = new URLSearchParams(gCalUrl.search)
 
@@ -22,16 +22,38 @@
       }
 
       const dateString = {{ .Params.date.Format "2006" }} + monthDict[{{ .Params.date.Format "Jan" }}] + {{ .Params.date.Format "2" }}
-      // const startTime = {{ .Params.start_time }}.split(" ")[0].replace(":", "").replace(" ", "").padStart(4, "0").padEnd(6, "0")
-      // const endTime = {{ .Params.start_time }}.split(" ")[2].replace(":", "").replace(" ", "").padStart(4, "0").padEnd(6, "0")
-      // Have to convert these to 12 hour time
+      let startTimeHour = parseInt({{ .Params.start_time }}.split(" ")[0].split(":")[0])
+      let endTimeHour = parseInt({{ .Params.start_time }}.split(" ")[2].split(":")[0])
 
+      // event begins in the morning and ends in the afternoon/evening
+      // only convert endtime to 24 hour time
+      // e.g 11:00 AM - 3:00 PM
+      if (startTimeHour > endTimeHour){
+        endTimeHour += 12
+      
+      // event starts and ends in the afternoon/evening OR starts in the morning and ends at 12PM
+      // convert both times to 24 hour time
+      // e.g 1:00 - 3:00 PM
+      // e.g 11:00 - 12:00 PM
+      }else if ( {{ .Params.start_time}}.includes("PM") && endTimeHour < 12){
+        startTimeHour += 12
+        endTimeHour += 12
+      }
+
+      // startTimeHour = (startTimeHour + 4) % 24
+      // endTimeHour = (endTimeHour + 4) % 24
+
+      // if an event starts and ends in the AM then they are already in 24 hour time
+      // e.g 10:00 - 11:00 AM
+
+      const startTime = startTimeHour.toString() + {{ .Params.start_time }}.split(" ")[0].split(":")[1] + "00"
+      const endTime = endTimeHour.toString() + {{ .Params.start_time }}.split(" ")[2].split(":")[1] + "00"
 
       details.append("action", "TEMPLATE");
       details.append("text", {{ .Params.title }});
       details.append("details", {{ .Params.short_description }});
       details.append("location", {{ .Params.location }});
-      details.append("dates", dateString + "T" + startTime + "E" + "%2F" + dateString + "T" + endTime);
+      details.append("dates", dateString + "T" + startTime + "E/" + dateString + "T" + endTime + "E");
       return gCalUrl + details;
     }
 
@@ -89,9 +111,9 @@
             <div class="event-subtitle">ADD TO CALENDAR</div>
             <div class="calendar-icons">
               <a id="g-cal-button" target="_blank"><iconify-icon  class="hvr-float" icon="akar-icons:google-fill" style="color: #c40729;" width="30"></iconify-icon></a>
-              <iconify-icon id="apple-button" class="hvr-float" icon="ant-design:apple-filled" style="color: #c40729;" width="30"></iconify-icon>
-              <iconify-icon id="outlook-button" class="hvr-float" icon="file-icons:microsoft-outlook" style="color: #c40729;" width="30"></iconify-icon>
-              <iconify-icon id="yahoo-button" class="hvr-float" icon="mdi:yahoo" style="color: #c40729;" width="30"></iconify-icon>
+              <a id="apple-button" target="_blank"><iconify-icon id="apple-button" class="hvr-float" icon="ant-design:apple-filled" style="color: #c40729;" width="30"></iconify-icon></a>
+              <a id="outlook-button" target="_blank"><iconify-icon id="outlook-button" class="hvr-float" icon="file-icons:microsoft-outlook" style="color: #c40729;" width="30"></iconify-icon></a>
+              <a id="yahoo-button" target="_blank"><iconify-icon id="yahoo-button" class="hvr-float" icon="mdi:yahoo" style="color: #c40729;" width="30"></iconify-icon></a>
             </div>
           </div>
         </div>

--- a/layouts/_default/event.html
+++ b/layouts/_default/event.html
@@ -54,7 +54,7 @@
         "Nov": 10,
         "Dec": 11
       }
-      
+
       const yearSplit = yearStr.split("T")[0].split("-")
       const dateSplit = dateStr.split(" - ")
 
@@ -107,8 +107,8 @@
     function generateAppleICSFileSingleDay(startDate, endDate){
       let startDateStr = `${startDate.getUTCFullYear()}${(startDate.getUTCMonth() + 1).toString().padStart(2, "0")}${startDate.getUTCDate().toString().padStart(2, "0")}T${startDate.getUTCHours().toString().padStart(2, "0")}${startDate.getUTCMinutes().toString().padStart(2, "0")}00Z`
       let endDateStr = `${endDate.getUTCFullYear()}${(endDate.getUTCMonth() + 1).toString().padStart(2, "0")}${endDate.getUTCDate().toString().padStart(2, "0")}T${endDate.getUTCHours().toString().padStart(2, "0")}${endDate.getUTCMinutes().toString().padStart(2, "0")}00Z`
-      
-      let event = 
+
+      let event =
         "BEGIN:VCALENDAR\n" +
         "VERSION:2.0\n" +
         "PRODID:-//ccss.carleton.ca//EN\n" +
@@ -138,7 +138,7 @@
       }else{
         [startDate, endDate] = convertDateMultiDay( {{ .Params.date }}, {{ .Params.start_time }} )
       }
-      
+
       gCalButton.href = generateGCalLinkSingleDay(startDate, endDate)
       outlookButton.href = generateOutlookLinkSingleDay(startDate, endDate)
       appleButton.href = generateAppleICSFileSingleDay(startDate, endDate)


### PR DESCRIPTION
This PR adds some "Add to calendar" buttons on the event page for Google Calendar, Outlook and Apple Calendar. These seem to be the three most used calendars among students

![image](https://user-images.githubusercontent.com/58529029/190905118-679898c6-407e-49e9-801f-a202c51c36e5.png)

There is separate logic for events that span over a single day (The Loft, Tech Talks, etc) and events that span over multiple days (Code challenge, Advent of Code, etc). This logic has been written to work with how single and multi-day events are currently written in their respective markdown files.

**Continue to write the markdown files for events as they have been written**. A refactor of how dates are stored would be nicer, however, that would mean that we'd have to make small edits to ~6 years of events which we can much more easily just work around.
