### PR TITLE
The headings now have different font size for h1,h2,h3

### DIFF
--- a/assets/scss/components/_overlaypost.scss
+++ b/assets/scss/components/_overlaypost.scss
@@ -39,11 +39,15 @@
   h1 {
     margin-top: 1.5rem;
     margin-bottom: 1.5rem;
+    font-size: 1.75em
   }
 
   h2 {
-    margin-top: 3rem;
+    margin-top: 1.5rem;
+    font-size: 1.65em
   }
+
+  h3 {font-size: 1.5em}
   p,
   ul,
   li {

--- a/assets/scss/components/_overlaypost.scss
+++ b/assets/scss/components/_overlaypost.scss
@@ -39,15 +39,17 @@
   h1 {
     margin-top: 1.5rem;
     margin-bottom: 1.5rem;
-    font-size: 1.75em
+    font-size: 1.75em;
   }
 
   h2 {
     margin-top: 1.5rem;
-    font-size: 1.65em
+    font-size: 1.65em;
   }
 
-  h3 {font-size: 1.5em}
+  h3 {
+    font-size: 1.5em;
+  }
   p,
   ul,
   li {


### PR DESCRIPTION
https://github.com/CarletonComputerScienceSociety/website/issues/260

changes the font size of headers from
On it!
Previously on my screen it renders h1 as 24px, h2 as 24px and h3 as 18.72px.
Now renders as 28px, 26.4px and 24px.