### PR TITLE
updated Lounge Notice on Home Page.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,9 +13,7 @@
   <div class="home-section-grid home-section-red">
     <div class="home-section-notice">
       <p style="color: white">
-        <i class="fas fa-info-circle"></i>The CCSS lounge and all in-person
-        services will be shortly resuming with the beginning of the Fall 2022
-        academic term.
+        <i class="fas fa-info-circle"></i>The CCSS lounge and all in-person services are available at Herzberg Laboratories in room 4135, near the Teaching Assistant (TA) Center!
       </p>
     </div>
   </div>


### PR DESCRIPTION
updated Lounge Notice on Home Page to The CCSS lounge and all in-person services are available at Herzberg Laboratories in room 4135, near the Teaching Assistant (TA) Center