### PR TITLE
Fix image pathname for COMP 1406 event

### DIFF
--- a/content/events/2023-2024/2024-03-04-comp1406-study-session.md
+++ b/content/events/2023-2024/2024-03-04-comp1406-study-session.md
@@ -4,7 +4,7 @@ title: "COMP 1406 Concept Review"
 date: 2024-03-04T00:00:00Z
 draft: false
 layout: event
-poster: "images/event_posters/2023-2024/comp1406_concept_review.jpg"
+poster: "images/event_posters/2023-2024/comp_1406_concept_review.jpg"
 poster_cover: "contain"
 poster_position: "center"
 short_description: "Confused about 1406 concepts? Join us for a mid-point review!"


### PR DESCRIPTION
As stated in title, this is to fix the visibility of the image.