### PR TITLE
Removed "Magazine" link in navbar

### DIFF
--- a/layouts/partials/navbar_temp.html
+++ b/layouts/partials/navbar_temp.html
@@ -51,11 +51,6 @@
             </li>
             <li><a href="/blog">BLOG</a></li>
             <li><a href="/community/organizations">ORGANIZATIONS</a></li>
-            <li>
-              <a href="http://magazine.carletoncomputersciencesociety.ca/"
-                >MAGAZINE</a
-              >
-            </li>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
Removed magazine link in navbar_temp partial.

Resolves #480 