### PR TITLE
chore: update github actions images

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/hugo-preview.yml
+++ b/.github/workflows/hugo-preview.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_preview:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/hugo-preview.yml
+++ b/.github/workflows/hugo-preview.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_preview:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
The ubuntu-20.04 image for GitHub Actions is now deprecated, failing our CI/CD. Information can be found here: https://github.com/actions/runner-images/issues/11101

This PR updates the github actions deploy to always use the latest ubuntu image so this is no longer a problem.