### PR TITLE
bug: fix homescreen subscribe button mobile highlight

### DIFF
--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -73,11 +73,11 @@
 .home-header-buttons {
   display: flex;
   align-items: center;
+  gap: 2.25rem;
 }
 
 .home-header-discord {
   margin-top: 0.1rem;
-  margin-left: 2.25rem;
   font-weight: bold;
   cursor: pointer;
   color: #c40729;


### PR DESCRIPTION
This PR resolves #596 

### Changes made

\- Removed margin-left property from .home-header-discord class.
\- Added gap property in .home-header-button class. 

Testing

\- Tested on mobile Chrome and desktop Chrome

## Screenshots

### Before and After on Desktop Chrome
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/73428d39-afb2-4bf6-b964-55b99e545c6a" />

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/87955c4e-190c-455f-bc81-abb391965488" />

### Before and After on Mobile Chrome

<img width="590" alt="image" src="https://github.com/user-attachments/assets/e955975c-6e20-4207-95d9-f43301d2b7c9" />
<img width="607" alt="image" src="https://github.com/user-attachments/assets/4c60b64b-6f34-4efb-a5f1-f6f4b0227f83" />

