### PR TITLE
Show upcoming earliest events on the front page.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -56,7 +56,8 @@
         ></span>
       </h1>
       <div class="home-events">
-        {{ range first 4 (where .Site.RegularPages "Section" "events" ).ByDate.Reverse }}
+        {{ $today := time.AsTime (now.Format "2006-01-02") }}
+        {{ range first 4 (where (where .Site.RegularPages "Section" "events") ".Date" "ge" $today).ByDate }}
           <a class="event_card_link hvr-float" href="{{ .RelPermalink }}"
             >{{- partial "event_card.html" . -}}</a
           >


### PR DESCRIPTION
Before, the furthest out events were being shown on the frontpage. This now shows events on the current day, then upcoming ones.

Time of screenshots: **Tue Sep 2, 2025** (url: `https://ccss.carleton.ca/`)
## Before
<img width="2376" height="1090" alt="image" src="https://github.com/user-attachments/assets/9c28fc4c-b346-4c55-a335-332356b76671" />

## After
<img width="2412" height="1140" alt="image" src="https://github.com/user-attachments/assets/53e69539-919e-4c95-9a02-e49a09cb5a3f" />
