### PR TITLE
fix(layouts): fix ordering logic of featured events

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -56,14 +56,14 @@
         ></span>
       </h1>
       <div class="home-events">
-          {{ $today := time.AsTime (now.Format "2006-01-02") }}
-          {{ $futureEvents := first 4 (where (where .Site.RegularPages "Section" "events") ".Date" "ge" $today).ByDate }}
-          {{ $eventsToShow := $futureEvents }}
-          {{ if lt (len $futureEvents) 4 }}
-            {{ $pastEvents := first (sub 4 (len $futureEvents)) (where (where .Site.RegularPages "Section" "events") ".Date" "lt" $today).ByDate.Reverse }}
-            {{ $eventsToShow = sort (append $futureEvents $pastEvents) "Date" }}
-          {{ end }}
-          {{ range $eventsToShow }}
+        {{ $today := time.AsTime (now.Format "2006-01-02") }}
+        {{ $futureEvents := first 4 (where (where .Site.RegularPages "Section" "events") ".Date" "ge" $today).ByDate }}
+        {{ $eventsToShow := $futureEvents }}
+        {{ if lt (len $futureEvents) 4 }}
+          {{ $pastEvents := first (sub 4 (len $futureEvents)) (where (where .Site.RegularPages "Section" "events") ".Date" "lt" $today).ByDate.Reverse }}
+          {{ $eventsToShow = sort (append $futureEvents $pastEvents) "Date" }}
+        {{ end }}
+        {{ range $eventsToShow }}
           <a class="event_card_link hvr-float" href="{{ .RelPermalink }}"
             >{{- partial "event_card.html" . -}}</a
           >

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -56,8 +56,14 @@
         ></span>
       </h1>
       <div class="home-events">
-        {{ $today := time.AsTime (now.Format "2006-01-02") }}
-        {{ range first 4 (where (where .Site.RegularPages "Section" "events") ".Date" "ge" $today).ByDate }}
+          {{ $today := time.AsTime (now.Format "2006-01-02") }}
+          {{ $futureEvents := first 4 (where (where .Site.RegularPages "Section" "events") ".Date" "ge" $today).ByDate }}
+          {{ $eventsToShow := $futureEvents }}
+          {{ if lt (len $futureEvents) 4 }}
+            {{ $pastEvents := first (sub 4 (len $futureEvents)) (where (where .Site.RegularPages "Section" "events") ".Date" "lt" $today).ByDate.Reverse }}
+            {{ $eventsToShow = sort (append $futureEvents $pastEvents) "Date" }}
+          {{ end }}
+          {{ range $eventsToShow }}
           <a class="event_card_link hvr-float" href="{{ .RelPermalink }}"
             >{{- partial "event_card.html" . -}}</a
           >


### PR DESCRIPTION
Fixes the ordering logic so that there are always 4 events on the featured events section of the homepage.

Before:
<img width="1090" height="554" alt="image" src="https://github.com/user-attachments/assets/0c84f7b8-539f-4ebc-9ef5-a2ff973c1c36" />

After:
<img width="1101" height="462" alt="image" src="https://github.com/user-attachments/assets/ba96135c-2544-44b8-abfc-2bf4a252d296" />