### PR TITLE
Update general election news to offer BoD Office Hours

### DIFF
--- a/content/news/2025-2026/2026-02-02-general-elections-2026-2027.md
+++ b/content/news/2025-2026/2026-02-02-general-elections-2026-2027.md
@@ -9,7 +9,7 @@ excerpt: "This year's board of directors elections have begun and it's time to n
 hideBanner: false
 featured: false
 author: Ryan Chung
-url: /news/general-elections-2026-2027
+url: /news/general-elections-2026-2027li
 categories:
 - announcement
 ---
@@ -40,6 +40,13 @@ The board consists of the following seven positions:
 Detailed descriptions and a breakdown of responsibilities for each position can be found here: **[CCSS BoD Position Descriptions](https://docs.google.com/document/d/1MZhBBUEz0VIOfWp82AwszhNO5W2KAijFjTRJV5g6rBc/edit?usp=sharing)**
 
 Members of the board are elected by the undergraduate Bachelor of Computer Science and Bachelor of Cybersecurity student body for a one-year term.
+
+## BoD Office Hours
+If you would like to have a chat with one of the current Board of Director members about what it is like being a BoD member, please book a call through Calendly:
+
+- Veronica Mordvinova, President, **[Link to Book Call](https://calendly.com/veronica-mordvinova-ccss/bod-election-office-hours)**
+- Cameron Stirrup, Director of Finance, **[Link to Book Call](https://calendly.com/cameron-stirrup/ccss-bod-office-hours)**
+- Nguyen-Hanh Nong, Director of Academics, **[Link to Book Call](https://calendly.com/nguyenhanh-nong-ccss/bod-office-hours)**
 
 ## How do I run for a position?
 


### PR DESCRIPTION
Adds BoD Office Hour links to allow potential candidates to ask questions for the 2026-2027 General Election.